### PR TITLE
feat: revamp AI Operations page as an AI-native studio

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -783,3 +783,96 @@ html {
         transition: none;
     }
 }
+
+/* Single "start a conversation" CTA — primary button + quiet whisper line.
+   Replaces the two-up ops-final grid when there's one primary path. */
+.ops-cta-solo {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.ops-cta-whisper {
+    font-family: var(--font-body);
+    font-size: 0.9375rem;
+    line-height: 1.55;
+    color: var(--color-text-secondary);
+    margin: 0;
+}
+
+.ops-cta-whisper a {
+    color: var(--color-text-primary);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-thickness: 1px;
+}
+
+.ops-cta-whisper a:hover {
+    text-decoration-color: var(--color-text-secondary);
+}
+
+.ops-cta-note {
+    margin: 0.25rem 0 0;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-secondary);
+}
+
+.ops-cta-note::before {
+    content: "// ";
+    color: var(--color-border);
+}
+
+/* Quiet inline text link inside body/FAQ copy */
+.ops-inline-link {
+    color: var(--color-text-primary);
+    font-weight: 500;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-thickness: 1px;
+    text-decoration-color: var(--color-border);
+    transition: text-decoration-color 150ms ease;
+}
+
+.ops-inline-link:hover {
+    text-decoration-color: var(--color-text-primary);
+}
+
+.ops-inline-link .ops-btn-arrow {
+    display: inline-block;
+    transition: transform 150ms ease;
+}
+
+.ops-inline-link:hover .ops-btn-arrow {
+    transform: translateX(2px);
+}
+
+/* Back link on worked-example / sub-pages */
+.ops-backlink {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    transition: color 150ms ease;
+}
+
+.ops-backlink:hover {
+    color: var(--color-text-primary);
+}
+
+.ops-backlink .ops-backlink-arrow {
+    transition: transform 150ms ease;
+}
+
+.ops-backlink:hover .ops-backlink-arrow {
+    transform: translateX(-2px);
+}

--- a/docs/plans/2026-06-13-ai-operations-page-revamp.md
+++ b/docs/plans/2026-06-13-ai-operations-page-revamp.md
@@ -1,0 +1,59 @@
+# AI Operations page revamp
+
+**Date:** 2026-06-13
+**Status:** Approved design, building
+
+## Goal
+
+Reposition `/operations` away from the narrow law-firm voicemail-automation pitch toward a
+broader identity: an **AI-native studio** (a "lab of sorts") that builds **bespoke AI systems**
+for companies, non-profits, and startups whose problem doesn't match anything off the shelf.
+
+## Decisions (from the founder)
+
+- **Law-firm content** → spun out to its own worked-example page at `/operations/inbound-practice/`.
+- **Offer model** → bespoke, "scope it together," no fixed pricing on the main page. Primary CTA = "Start a conversation."
+- **Lab framing** → AI-native studio, low-hype. The lab reads as a *method*, not a badge:
+  "We build small, working things fast, then harden the ones that earn it."
+- **Audience** → speak to all, organized by problem, never by audience type.
+- **Capabilities** → focus on the one provable thing: *the system no vendor sells.* No multi-capability menu.
+- **Naming** → generic ("the practitioner who builds your system"). No bios.
+- **CTA target** → cal.com/collectively/review (book a call), email as the quiet secondary.
+- **Proof** → client-logo strip for now; the worked example gets one quiet link (FAQ), not a featured teaser.
+
+## Voice rules (anchor)
+
+Plainspoken, declarative, anti-hype. Sentence-case headings ending in a period. Contrast
+constructions ("X, not Y"). Honest to the point of self-disclosure. Concrete nouns and real
+figures over adjectives. Mono `//` eyebrows + terminal-style analog footers. Avoid: AI-slop
+modifiers (AI-powered, unlock, leverage, seamless, cutting-edge), negative-parallelism AI tell
+("it's not X, it's Y"), tricolons, fixed pricing/tiers, fear/disruption framing, R&D cosplay.
+
+## Page structure (`/operations`)
+
+1. Hero — "We build the system no vendor sells." + single CTA.
+2. Positioning blurb — cooperative + enterprise-UX proof + the lab method line.
+3. What we build — "Most AI gets bought and never shipped." + an `ops-list` of the shapes the work takes.
+4. Why us — 3 `ops-card`s: cooperative-not-agency / model-is-the-easy-part / we'll-tell-you-what-AI-shouldn't-do.
+5. How it works — 4 `ops-steps`: conversation → written brief → build → handoff or care.
+6. Selected clients — reuse the homepage logo carousel.
+7. The honest answers — FAQ reframed off law-firm specifics (one quiet worked-example link here).
+8. Final CTA — single "Start a conversation" path + quiet email whisper.
+
+## Worked-example page (`/operations/inbound-practice/`)
+
+Relocate the law-firm content, reframed as a story (problem → what we built → honest terms).
+Pricing ($3,500 setup / $850 monthly) lives here, where it's a concrete example. Keeps the strong
+receptionist lines. Becomes the template for future worked examples.
+
+## Other changes
+
+- Homepage card ([index.html]) — update "Hire the collective" body to the new positioning; retire the `// $3,500+ · Retainer` analog.
+- Align "collective" → "cooperative" in body copy.
+- `og_image` → `/img/main/lead.png` (the missing `/img/operations/og.png` referenced before doesn't exist).
+
+## Reuse / build notes
+
+- Everything reuses the existing `ops-*` component system; minimal new CSS (single-CTA whisper + inline link helpers).
+- `ops-fade` scroll-reveal needs BOTH the CSS and the inline IntersectionObserver script on each page.
+- Logo carousel duplicates 8 logos ×2 for the seamless `translateX(-50%)` loop — do not consolidate.

--- a/inbound-practice.html
+++ b/inbound-practice.html
@@ -1,0 +1,204 @@
+---
+layout: default
+permalink: /operations/inbound-practice/
+title: "Inbound Practice — a worked example, Collectively Made"
+description: "A worked example from Collectively Made: AI intake for a professional-services firm losing inbound inquiries to voicemail, unread email, and slow follow-up."
+og_image: /img/main/lead.png
+---
+
+<main class="ops-page">
+
+    <!-- Hero -->
+    <section class="ops-section ops-hero">
+        <div class="ops-container-wide">
+            <a href="/operations/" class="ops-backlink ops-fade"><span class="ops-backlink-arrow" aria-hidden="true">←</span> AI Operations</a>
+            <p class="ops-eyebrow ops-fade" style="margin-top: 1.5rem;">A worked example</p>
+            <h1 class="ops-fade">A quiet system for a firm losing calls to voicemail.</h1>
+            <p class="ops-subhead ops-fade">AI operations for firms that care how they sound. Most AI automation feels bolted on. We designed this one to sound like the firm on its best day, every day.</p>
+        </div>
+    </section>
+
+    <hr class="ops-rule" />
+
+    <!-- The problem -->
+    <section class="ops-section-tight">
+        <div class="ops-container-wide">
+            <div class="ops-section-head ops-fade">
+                <p class="ops-eyebrow">The problem</p>
+                <h2 class="ops-h2">Every missed call was a client who'd already moved on.</h2>
+            </div>
+            <p class="ops-body ops-fade">
+                A professional-services firm was losing inbound inquiries to voicemail, unread email, and slow follow-up. The work didn't need a louder front desk—it needed something to close the gap after hours and during the lunch-hour rush, without making the firm feel like someone else's. So we built one.
+            </p>
+        </div>
+    </section>
+
+    <hr class="ops-rule" />
+
+    <!-- What we built -->
+    <section class="ops-section">
+        <div class="ops-container-wide">
+            <div class="ops-section-head ops-fade">
+                <p class="ops-eyebrow">What we built</p>
+                <h2 class="ops-h2">Inbound Practice</h2>
+                <p class="ops-subhead-2">A voice receptionist, a structured intake flow, and a clean handoff to the firm's practice-management system. Built in four weeks.</p>
+            </div>
+
+            <ul class="ops-list ops-fade">
+                <li>Voice AI receptionist trained on the firm's actual phrasing, hours, and referral rules. Live call monitoring in the first two weeks.</li>
+                <li>Structured intake: name, matter type, urgency, source, consent, captured the same way every time.</li>
+                <li>Integration with the firm's existing system (the practice runs with Clio, Dentrix, Open Dental, MyCase, Karbon, SimplePractice, Wealthbox, and similar).</li>
+            </ul>
+
+            <p class="ops-pricing ops-fade">
+                Setup from $3,500. Monthly care from $850. Month-to-month after the first 90 days. No long contract.
+            </p>
+        </div>
+    </section>
+
+    <hr class="ops-rule" />
+
+    <!-- How it works -->
+    <section class="ops-section">
+        <div class="ops-container-wide">
+            <div class="ops-section-head ops-fade">
+                <p class="ops-eyebrow">How it works</p>
+                <h2 class="ops-h2">Four steps, about four weeks.</h2>
+            </div>
+
+            <div class="ops-steps ops-fade">
+                <article class="ops-card">
+                    <p class="ops-card-label">Step 01</p>
+                    <h3 class="ops-card-title">Intake audit</h3>
+                    <p class="ops-card-body">We run a diagnostic on your current intake. You get a one-page PDF. Free, no pitch attached.</p>
+                    <p class="ops-card-analog">// Free · 1-page PDF</p>
+                </article>
+                <article class="ops-card">
+                    <p class="ops-card-label">Step 02</p>
+                    <h3 class="ops-card-title">30-minute review</h3>
+                    <p class="ops-card-body">We walk the audit, you tell us what's wrong with it, and we scope a fix—on a 30-minute call.</p>
+                    <p class="ops-card-analog">// 30 minutes · Cal.com</p>
+                </article>
+                <article class="ops-card">
+                    <p class="ops-card-label">Step 03</p>
+                    <h3 class="ops-card-title">Build</h3>
+                    <p class="ops-card-body">Four weeks from signed proposal to live deployment, including a week of monitored soft launch.</p>
+                    <p class="ops-card-analog">// 4 weeks · Incl. soft launch</p>
+                </article>
+                <article class="ops-card">
+                    <p class="ops-card-label">Step 04</p>
+                    <h3 class="ops-card-title">Care</h3>
+                    <p class="ops-card-body">Monthly retainer covers monitoring, tuning, and one small change request per month.</p>
+                    <p class="ops-card-analog">// Monthly · Month-to-month</p>
+                </article>
+            </div>
+        </div>
+    </section>
+
+    <hr class="ops-rule" />
+
+    <!-- FAQ -->
+    <section class="ops-section">
+        <div class="ops-container-wide">
+            <div class="ops-section-head ops-section-head--solo ops-fade">
+                <h2 class="ops-h2">The honest answers.</h2>
+            </div>
+
+            <div class="ops-faq ops-fade">
+                <details>
+                    <summary>What does it actually sound like when someone calls?</summary>
+                    <p>Like a receptionist you trained. We write the opening line, the hold phrasing, and the transfer language with you. We also record and review the first two weeks of live calls together. Nothing about the voice has to feel generic.</p>
+                </details>
+                <details>
+                    <summary>What systems do you integrate with?</summary>
+                    <p>Most small-firm practice management and CRM tools, including Clio, MyCase, Dentrix, Open Dental, Karbon, SimplePractice, and Wealthbox. If you're on something else, we'll tell you honestly on the 30-minute review call whether it will work.</p>
+                </details>
+                <details>
+                    <summary>Who owns the data?</summary>
+                    <p>You do. All call recordings, transcripts, and intake records live in an account you own. We work inside it.</p>
+                </details>
+                <details>
+                    <summary>What if it doesn't work?</summary>
+                    <p>The first 30 days are a pilot. If you want out at day 30, you keep the intake form and the integrations we built, and we part cleanly. No prorated refund games.</p>
+                </details>
+                <details>
+                    <summary>How is this different from hiring another receptionist?</summary>
+                    <p>A receptionist works 40 hours a week. This covers the other 128, and the lunch hour, and the moment when your existing receptionist is already on the phone with someone else. It doesn't replace them. It backs them up.</p>
+                </details>
+                <details>
+                    <summary>How is this different from the other AI answering services?</summary>
+                    <p>Most AI answering services are a product looking for a customer. We're a practice that happens to use one of those products underneath, with design work on top. The honest answer is the design work is the thing you're paying for.</p>
+                </details>
+            </div>
+        </div>
+    </section>
+
+    <!-- Final CTA -->
+    <section class="ops-section">
+        <div class="ops-container-wide">
+            <div class="ops-section-head ops-section-head--solo ops-fade">
+                <h2 class="ops-h2">Have a problem shaped like this one?</h2>
+                <p class="ops-subhead-2">This was one firm's gap. Yours will be different. Tell us what you're working on, and we'll tell you honestly whether we're the right fit.</p>
+            </div>
+
+            <div class="ops-cta-solo ops-fade">
+                <a href="https://cal.com/collectively/review" target="_blank" rel="noopener noreferrer" class="ops-btn ops-btn-primary">
+                    Start a conversation
+                    <span class="ops-btn-arrow" aria-hidden="true">→</span>
+                </a>
+                <p class="ops-cta-whisper">
+                    Prefer to start quiet? <a href="mailto:alex@collectivelymade.com?subject=Let%27s%20talk&amp;body=Hi%20Alex%2C%0A%0AHere%27s%20what%20we%27re%20working%20on%3A%0A%0A">Send a note</a>.
+                </p>
+                <p class="ops-cta-note">No intake form. Just a conversation.</p>
+            </div>
+        </div>
+    </section>
+
+</main>
+
+<script>
+    // Subtle fade-in on scroll, honoring reduced motion.
+    // Uses IntersectionObserver + a scroll safety net so elements never stay
+    // stuck invisible after a jump-scroll or rapid flick.
+    (function() {
+        const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const fades = document.querySelectorAll('.ops-fade');
+        if (prefersReduced) {
+            fades.forEach(el => el.classList.add('is-visible'));
+            return;
+        }
+
+        const reveal = el => el.classList.add('is-visible');
+
+        if ('IntersectionObserver' in window) {
+            const io = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        reveal(entry.target);
+                        io.unobserve(entry.target);
+                    }
+                });
+            }, { threshold: 0.01 });
+            fades.forEach(el => io.observe(el));
+        }
+
+        // Safety net: any element whose top has entered (or passed) the
+        // viewport should be revealed, regardless of IO timing.
+        const sweep = () => {
+            const bottom = window.scrollY + window.innerHeight;
+            fades.forEach(el => {
+                if (el.classList.contains('is-visible')) return;
+                const r = el.getBoundingClientRect();
+                if (r.top + window.scrollY < bottom) reveal(el);
+            });
+        };
+        sweep();
+        window.addEventListener('load', sweep);
+        let ticking = false;
+        window.addEventListener('scroll', () => {
+            if (ticking) return;
+            ticking = true;
+            requestAnimationFrame(() => { sweep(); ticking = false; });
+        }, { passive: true });
+    })();
+</script>

--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@ layout: default
                 <a href="/operations/" class="ops-card ops-card--link">
                     <p class="ops-card-label">01</p>
                     <h2 class="ops-card-title">Hire the collective.</h2>
-                    <p class="ops-card-body">Currently building AI operations for small businesses.</p>
-                    <p class="ops-card-analog">// $3,500+ · Retainer</p>
+                    <p class="ops-card-body">Bespoke AI systems for the problems no vendor sells.</p>
+                    <p class="ops-card-analog">// AI Operations · By conversation</p>
                 </a>
 
                 <a href="https://cal.com/collectively/discovery" target="_blank" rel="noopener noreferrer" class="ops-card ops-card--link">

--- a/operations.html
+++ b/operations.html
@@ -1,9 +1,9 @@
 ---
 layout: default
 permalink: /operations/
-title: "Operations, Collectively Made"
-description: "Collectively Made is a small, worker-owned design collective. Operations is our practice for professional service firms that are losing inbound inquiries to voicemail, unread email, and slow follow-up."
-og_image: /img/operations/og.png
+title: "AI Operations, Collectively Made"
+description: "Collectively Made is a worker-owned cooperative building bespoke AI systems — the tools and automations no vendor sells — for companies, non-profits, and startups."
+og_image: /img/main/lead.png
 ---
 
 <main class="ops-page">
@@ -12,15 +12,14 @@ og_image: /img/operations/og.png
     <section class="ops-section ops-hero">
         <div class="ops-container-wide">
             <p class="ops-eyebrow ops-fade">Operations, from Collectively Made</p>
-            <h1 class="ops-fade">AI operations for firms that care how they sound.</h1>
-            <p class="ops-subhead ops-fade">Most AI automation feels bolted on. We design yours to sound like your firm on its best day, every day.</p>
+            <h1 class="ops-fade">We build the system no vendor sells.</h1>
+            <p class="ops-subhead ops-fade">For the companies, non-profits, and startups whose real problem doesn't match anything off the shelf.</p>
 
             <div class="mt-10 flex flex-wrap gap-3 ops-fade">
                 <a href="https://cal.com/collectively/review" target="_blank" rel="noopener noreferrer" class="ops-btn ops-btn-primary">
-                    Book a 30-minute review
+                    Start a conversation
                     <span class="ops-btn-arrow" aria-hidden="true">→</span>
                 </a>
-                <span class="ops-btn ops-btn-secondary ops-btn--disabled" aria-disabled="true" title="Temporarily unavailable">See a sample audit</span>
             </div>
         </div>
     </section>
@@ -31,8 +30,27 @@ og_image: /img/operations/og.png
     <section class="ops-section-tight">
         <div class="ops-container-wide">
             <p class="ops-body ops-fade">
-                <strong>Collectively Made</strong> is a small, worker-owned design collective. Operations is our practice for professional service firms that are losing inbound inquiries to voicemail, unread email, and slow follow-up. We build quiet systems that close the gap without making your firm feel like someone else's.
+                <strong>Collectively Made</strong> is a worker-owned cooperative of designers, engineers, and strategists. We build bespoke AI for organizations that can't find what they need off the shelf — quiet systems that close the gap without making your work feel like someone else's. The judgment comes from twelve years of shipping inside Fortune&nbsp;500 engineering organizations; the nimbleness comes from not being one. We work like a lab: small, working things first, then we harden the ones that earn it.
             </p>
+        </div>
+    </section>
+
+    <hr class="ops-rule" />
+
+    <!-- What we build -->
+    <section class="ops-section">
+        <div class="ops-container-wide">
+            <div class="ops-section-head ops-fade">
+                <p class="ops-eyebrow">What we build</p>
+                <h2 class="ops-h2">Most AI gets bought and never shipped.</h2>
+                <p class="ops-subhead-2">We build the part that has to work — and make it stable, observable, and yours. Same craft whether you're a startup, a non-profit, or a Fortune 500 team; the only thing that changes is the problem.</p>
+            </div>
+
+            <ul class="ops-list ops-fade">
+                <li>A tool your team actually opens — built around how you already work, not another tab to babysit.</li>
+                <li>The automation no vendor will build for just you: the copying-between-systems that quietly eats your week.</li>
+                <li>A narrow, trustworthy agent for one real task, with the judgment about what "good" means written in.</li>
+            </ul>
         </div>
     </section>
 
@@ -44,43 +62,20 @@ og_image: /img/operations/og.png
             <div class="ops-cols ops-fade">
                 <article class="ops-card">
                     <p class="ops-card-label">/01</p>
-                    <h2 class="ops-card-title">Design-led, not automation-led.</h2>
-                    <p class="ops-card-body">We write the voice, audit the transcripts, and tune the handoffs. The system sounds like a colleague of yours, not a bot.</p>
-                </article>
-                <article class="ops-card">
-                    <p class="ops-card-label">/02</p>
-                    <h2 class="ops-card-title">A collective, not an agency.</h2>
+                    <h2 class="ops-card-title">A cooperative, not an agency.</h2>
                     <p class="ops-card-body">We're accountable to the work, not to account executives. You talk to the practitioner building your system, every time.</p>
                 </article>
                 <article class="ops-card">
+                    <p class="ops-card-label">/02</p>
+                    <h2 class="ops-card-title">The model is the easy part.</h2>
+                    <p class="ops-card-body">A working AI system is mostly the surrounding craft: integration, verification, the judgment about what "good" means here. That's what you're paying for.</p>
+                </article>
+                <article class="ops-card">
                     <p class="ops-card-label">/03</p>
-                    <h2 class="ops-card-title">Twelve years of enterprise UX, in a shop of one.</h2>
-                    <p class="ops-card-body">The judgment comes from shipping systems inside Fortune 500 engineering organizations. The nimbleness comes from not being one.</p>
+                    <h2 class="ops-card-title">We'll tell you what AI shouldn't do.</h2>
+                    <p class="ops-card-body">If an off-the-shelf tool already solves it, we'll say so. If a task can't be automated safely, we'll say that too. Honest scope beats a longer capability list.</p>
                 </article>
             </div>
-        </div>
-    </section>
-
-    <hr class="ops-rule" />
-
-    <!-- Service: Inbound Practice -->
-    <section class="ops-section">
-        <div class="ops-container-wide">
-            <div class="ops-section-head ops-fade">
-                <p class="ops-eyebrow">The practice</p>
-                <h2 class="ops-h2">Inbound Practice</h2>
-                <p class="ops-subhead-2">A voice receptionist, a structured intake flow, and a clean handoff to your CRM or practice management system. Built in four weeks.</p>
-            </div>
-
-            <ul class="ops-list ops-fade">
-                <li>Voice AI receptionist trained on your firm's actual phrasing, hours, and referral rules. Live call monitoring in the first two weeks.</li>
-                <li>Structured intake: name, matter type, urgency, source, consent, captured the same way every time.</li>
-                <li>Integration with your existing system (Clio, Dentrix, Open Dental, MyCase, Karbon, SimplePractice, Wealthbox, and similar).</li>
-            </ul>
-
-            <p class="ops-pricing ops-fade">
-                Setup from $3,500. Monthly care from $850. Month-to-month after the first 90 days. No long contract.
-            </p>
         </div>
     </section>
 
@@ -91,54 +86,67 @@ og_image: /img/operations/og.png
         <div class="ops-container-wide">
             <div class="ops-section-head ops-fade">
                 <p class="ops-eyebrow">How it works</p>
-                <h2 class="ops-h2">Four steps, about four weeks.</h2>
+                <h2 class="ops-h2">Every engagement starts with a conversation, not a proposal.</h2>
             </div>
 
             <div class="ops-steps ops-fade">
                 <article class="ops-card">
                     <p class="ops-card-label">Step 01</p>
-                    <h3 class="ops-card-title">Intake audit</h3>
-                    <p class="ops-card-body">We run a diagnostic on your current intake. You get a one-page PDF. Free, no pitch attached.</p>
-                    <p class="ops-card-analog">// Free · 1-page PDF</p>
+                    <h3 class="ops-card-title">A conversation</h3>
+                    <p class="ops-card-body">Tell us what you're working on. We'll tell you honestly whether we're the right fit—and if we're not, who might be.</p>
+                    <p class="ops-card-analog">// Free · No pitch</p>
                 </article>
                 <article class="ops-card">
                     <p class="ops-card-label">Step 02</p>
-                    <h3 class="ops-card-title">30-minute review</h3>
-                    <p class="ops-card-body">We walk the audit, you tell us what's wrong with it, and we scope a fix—on a 30-minute call.</p>
-                    <p class="ops-card-analog">// 30 minutes · Cal.com</p>
+                    <h3 class="ops-card-title">A written brief</h3>
+                    <p class="ops-card-body">We scope the shape of the work together: what's worth building, what isn't, and roughly how long it takes.</p>
+                    <p class="ops-card-analog">// We scope it together</p>
                 </article>
                 <article class="ops-card">
                     <p class="ops-card-label">Step 03</p>
                     <h3 class="ops-card-title">Build</h3>
-                    <p class="ops-card-body">Four weeks from signed proposal to live deployment, including a week of monitored soft launch.</p>
-                    <p class="ops-card-analog">// 4 weeks · Incl. soft launch</p>
+                    <p class="ops-card-body">Small, working things, fast—with visibility the whole way. We ship narrow before broad, and harden what earns it.</p>
+                    <p class="ops-card-analog">// Weeks, not quarters</p>
                 </article>
                 <article class="ops-card">
                     <p class="ops-card-label">Step 04</p>
-                    <h3 class="ops-card-title">Care</h3>
-                    <p class="ops-card-body">Monthly retainer covers monitoring, tuning, and one small change request per month.</p>
-                    <p class="ops-card-analog">// Monthly · Month-to-month</p>
+                    <h3 class="ops-card-title">Handoff or care</h3>
+                    <p class="ops-card-body">We leave you able to maintain it, or we stay on month-to-month. No long contract either way.</p>
+                    <p class="ops-card-analog">// You own it</p>
                 </article>
             </div>
         </div>
     </section>
 
-    <!-- Case studies — commented out for now
     <hr class="ops-rule" />
 
-    <section class="ops-section-tight">
+    <!-- Selected clients -->
+    <section class="ops-section">
         <div class="ops-container-wide">
-            <div class="ops-fade">
-                <p class="ops-eyebrow">Case studies</p>
-                <p class="ops-case-note">
-                    Case studies will publish here as our first cohort of firms completes their builds. If you'd like to be one, your audit is free and your first three months of care are half price.
-                </p>
+            <p class="ops-eyebrow ops-fade">Selected clients</p>
+            <div class="logo-carousel ops-fade mt-7">
+                <div class="logo-track">
+                    <img src="/img/logos/adidas_white.svg" alt="Adidas" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/Omaha_steaks_white.svg" alt="Omaha Steaks" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/OR_white.svg" alt="Outdoor Research" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/University_of_Nebraska–Lincoln_logo 1.svg" alt="University of Nebraska–Lincoln" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/city-of-lnk-logo.svg" alt="City of Lincoln" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/ILC-logo.svg" alt="ILC" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/marriott_white.svg" alt="Marriott International" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/archrival_white.svg" alt="Archrival" class="px-2 client-logo shrink-0">
+                    <!-- Duplicate for seamless loop -->
+                    <img src="/img/logos/adidas_white.svg" alt="Adidas" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/Omaha_steaks_white.svg" alt="Omaha Steaks" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/OR_white.svg" alt="Outdoor Research" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/University_of_Nebraska–Lincoln_logo 1.svg" alt="University of Nebraska–Lincoln" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/city-of-lnk-logo.svg" alt="City of Lincoln" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/ILC-logo.svg" alt="ILC" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/marriott_white.svg" alt="Marriott International" class="px-2 client-logo shrink-0">
+                    <img src="/img/logos/archrival_white.svg" alt="Archrival" class="px-2 client-logo shrink-0">
+                </div>
             </div>
         </div>
     </section>
-
-    <hr class="ops-rule" />
-    -->
 
     <hr class="ops-rule" />
 
@@ -151,28 +159,28 @@ og_image: /img/operations/og.png
 
             <div class="ops-faq ops-fade">
                 <details>
-                    <summary>What does it actually sound like when someone calls?</summary>
-                    <p>Like a receptionist you trained. We write the opening line, the hold phrasing, and the transfer language with you. We also record and review the first two weeks of live calls together. Nothing about the voice has to feel generic.</p>
+                    <summary>Why is there no pricing on this page?</summary>
+                    <p>Because the right number depends on your problem, and we won't know it until we understand the work. The first conversation is where we scope that—not a sales call, a fit-read. Pricing for a specific build lives with that build.</p>
                 </details>
                 <details>
-                    <summary>What systems do you integrate with?</summary>
-                    <p>Most small-firm practice management and CRM tools, including Clio, MyCase, Dentrix, Open Dental, Karbon, SimplePractice, and Wealthbox. If you're on something else, we'll tell you honestly on the 30-minute review call whether it will work.</p>
+                    <summary>Who actually does the work?</summary>
+                    <p>The practitioner who scoped it. We're worker-owned, so there's no account executive in the middle and no junior handoff. You work with the person building your system, start to finish.</p>
                 </details>
                 <details>
-                    <summary>Who owns the data?</summary>
-                    <p>You do. All call recordings, transcripts, and intake records live in an account you own. We work inside it.</p>
+                    <summary>What if AI isn't the right answer?</summary>
+                    <p>Then we'll say so. Sometimes the honest answer is that an off-the-shelf tool already covers it, or that a task shouldn't be automated yet. We'd rather lose the project than build you something that shouldn't exist.</p>
                 </details>
                 <details>
-                    <summary>What if it doesn't work?</summary>
-                    <p>The first 30 days are a pilot. If you want out at day 30, you keep the intake form and the integrations we built, and we part cleanly. No prorated refund games.</p>
+                    <summary>How are you different from an AI agency?</summary>
+                    <p>Most AI shops are a product looking for a customer. We're a practice that happens to use these tools underneath, with judgment on top—what to build, what to refuse, what "good" means for you. That's the thing you're paying for. We've done this work before; here's one we can talk about openly: <a href="/operations/inbound-practice/" class="ops-inline-link">a worked example <span class="ops-btn-arrow" aria-hidden="true">→</span></a></p>
                 </details>
                 <details>
-                    <summary>How is this different from hiring another receptionist?</summary>
-                    <p>A receptionist works 40 hours a week. This covers the other 128, and the lunch hour, and the moment when your existing receptionist is already on the phone with someone else. It doesn't replace them. It backs them up.</p>
+                    <summary>Who owns what we build?</summary>
+                    <p>You do. The system, the data, the accounts it runs in—all yours. We build inside what you own, and we leave you able to maintain it.</p>
                 </details>
                 <details>
-                    <summary>How is this different from the other AI answering services?</summary>
-                    <p>Most AI answering services are a product looking for a customer. We're a practice that happens to use one of those products underneath, with design work on top. The honest answer is the design work is the thing you're paying for.</p>
+                    <summary>What if we want to walk away?</summary>
+                    <p>You can. We work month-to-month once a build is live, with no long contract. You keep everything we made together. No prorated refund games.</p>
                 </details>
             </div>
         </div>
@@ -182,28 +190,19 @@ og_image: /img/operations/og.png
     <section class="ops-section">
         <div class="ops-container-wide">
             <div class="ops-section-head ops-section-head--solo ops-fade">
-                <h2 class="ops-h2">Two ways in.</h2>
+                <h2 class="ops-h2">Start a conversation.</h2>
+                <p class="ops-subhead-2">Tell us what you're working on. We'll tell you honestly whether we're the right fit.</p>
             </div>
 
-            <div class="ops-final ops-fade">
-                <article class="ops-card ops-final-item">
-                    <p class="ops-card-label">/01/collectively</p>
-                    <h3 class="ops-card-title">The 30-minute review.</h3>
-                    <p class="ops-card-body">We walk your intake, scope a fix, and decide together whether to work together.</p>
-                    <a href="https://cal.com/collectively/review" target="_blank" rel="noopener noreferrer" class="ops-btn ops-btn-primary">
-                        Book the 30-minute review
-                        <span class="ops-btn-arrow" aria-hidden="true">→</span>
-                    </a>
-                </article>
-                <article class="ops-card ops-final-item">
-                    <p class="ops-card-label">/02/email</p>
-                    <h3 class="ops-card-title">A free intake audit.</h3>
-                    <p class="ops-card-body">Prefer to start quiet? Send us a note. We'll return a one-page audit of your current intake, free.</p>
-                    <a href="mailto:alex@collectivelymade.com?subject=Intake%20audit%20request&amp;body=Hi%20Alex%2C%0A%0AI%27d%20like%20to%20request%20a%20free%20intake%20audit%20for%20my%20firm.%20Here%27s%20a%20bit%20of%20context%3A%0A%0A" class="ops-btn ops-btn-secondary">
-                        Email us
-                        <span class="ops-btn-arrow" aria-hidden="true">→</span>
-                    </a>
-                </article>
+            <div class="ops-cta-solo ops-fade">
+                <a href="https://cal.com/collectively/review" target="_blank" rel="noopener noreferrer" class="ops-btn ops-btn-primary">
+                    Start a conversation
+                    <span class="ops-btn-arrow" aria-hidden="true">→</span>
+                </a>
+                <p class="ops-cta-whisper">
+                    Prefer to start quiet? <a href="mailto:alex@collectivelymade.com?subject=Let%27s%20talk&amp;body=Hi%20Alex%2C%0A%0AHere%27s%20what%20we%27re%20working%20on%3A%0A%0A">Send a note</a>.
+                </p>
+                <p class="ops-cta-note">No intake form. Just a conversation.</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary

`/operations` now positions Collectively Made as an AI-native studio that builds bespoke AI systems for companies, non-profits, and startups. It replaces the previous page, which was built entirely around one offering: automating law-firm voicemail. The page leads with the problem ("the system no vendor sells"), drops fixed pricing in favor of a single "start a conversation" model, and moves the law-firm work to its own worked-example page so the main page stays broad.

## What changed

- **Organized by problem, not audience.** The page reaches every audience through the work itself instead of splitting into "for startups / for enterprises" sections. It focuses on the one capability we can stand behind today (a system no vendor sells) rather than a speculative menu.
- **No price list, by design.** Pricing left the main page. A concrete 4-step process (conversation, written brief, build, handoff or care) gives the "scope it together" model a clear shape, so "start a conversation" is not a blind funnel.
- **The law-firm work is now a worked example.** It lives at `/operations/inbound-practice/`, reframed as a story (problem, what we built, terms), with its pricing kept there where it reads as a real example. The main page links to it once, quietly, from the FAQ.
- **Proof via the client-logo strip.** Reuses the homepage carousel as the credibility anchor.
- **The "AI lab" framing reads as method, not a badge.** Stated plainly in the positioning: build small working things fast, then harden the ones that earn it.

The homepage "Hire the collective" card was updated to match the new positioning.

## Notes for review

- `og_image` points at the existing `/img/main/lead.png` for both pages. The previously referenced `/img/operations/og.png` never existed. Real per-page OG images are a good follow-up.
- Built on the existing `ops-*` component system. New CSS is limited to a single-CTA whisper line, a quiet inline link, and a sub-page back link.
- Verified across desktop, dark mode, and mobile via a static render. Local `bundle exec jekyll serve` is currently broken by an unrelated Ruby/bundler version mismatch; GitHub Pages builds on merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
